### PR TITLE
feat(login): increased max_length of password to 50

### DIFF
--- a/application/views/login/login_index.php
+++ b/application/views/login/login_index.php
@@ -38,7 +38,7 @@ echo form_open('login/submit', array('id'=>'login','class'=>'cssform'), array('p
 			'id' => 'password',
 			'size' => '20',
 			'tabindex' => tab_index(),
-			'maxlength' => '20',
+			'maxlength' => '50',
 		));
 		?>
 	</p>


### PR DESCRIPTION
Using a password manager I had issues when copy pasting a password which exceeded the maxlength of 20 of the password field. That's why I made this pull request which increases the length of the field to 50 chars.